### PR TITLE
fix: drop the hacky replacement of code action command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Same as VSCode. The list below may be outdated.
 - `refactor.rewrite.arrow.braces`
 - `refactor.rewrite.property.generateAccessors`
 
+Inline refactor action can carry an additional `editor.action.rename` command for immediate renaming of new extracted symbol. The command should be executed on the client side. Command arguments:
+
+```
+[uri: DocumentUri, position: Position][]
+```
+
 ### Update paths on rename
 
 Require client to send [`workspace/didRenameFiles`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didRenameFiles) notification on rename of file/folder.

--- a/packages/service/patches/080-convert-code-action-command.patch
+++ b/packages/service/patches/080-convert-code-action-command.patch
@@ -1,0 +1,118 @@
+diff --git a/src/languageFeatures/quickFix.ts b/src/languageFeatures/quickFix.ts
+index bc24420..62fed3d 100644
+--- a/src/languageFeatures/quickFix.ts
++++ b/src/languageFeatures/quickFix.ts
+@@ -18,6 +18,7 @@ import { DiagnosticsManager } from './diagnostics';
+ import FileConfigurationManager from './fileConfigurationManager';
+ import { applyCodeActionCommands, getEditForCodeAction } from './util/codeAction';
+ import { conditionalRegistration, requireSomeCapability } from './util/dependentRegistration';
++import { commandsConverter } from '../../../share';
+ 
+ type ApplyCodeActionCommand_args = {
+ 	readonly document: vscode.TextDocument;
+@@ -94,7 +95,8 @@ class ApplyCodeActionCommand implements Command {
+ }
+ 
+ type ApplyFixAllCodeAction_args = {
+-	readonly action: VsCodeFixAllCodeAction;
++	readonly tsAction: Proto.CodeFixAction,
++	readonly combinedResponse: Proto.GetCombinedCodeFixResponse;
+ };
+ 
+ class ApplyFixAllCodeAction implements Command {
+@@ -117,11 +119,11 @@ class ApplyFixAllCodeAction implements Command {
+ 			}
+ 		*/
+ 		this.telemetryReporter.logTelemetry('quickFixAll.execute', {
+-			fixName: args.action.tsAction.fixName
++			fixName: args.tsAction.fixName
+ 		});
+ 
+-		if (args.action.combinedResponse) {
+-			await applyCodeActionCommands(this.client, args.action.combinedResponse.body.commands, nulToken);
++		if (args.combinedResponse) {
++			await applyCodeActionCommands(this.client, args.combinedResponse.body.commands, nulToken);
+ 		}
+ 	}
+ }
+@@ -318,6 +320,11 @@ class TypeScriptQuickFixProvider implements vscode.CodeActionProvider<VsCodeCode
+ 		if (response.type === 'response') {
+ 			codeAction.combinedResponse = response;
+ 			codeAction.edit = typeConverters.WorkspaceEdit.fromFileCodeEdits(this.client, response.body.changes);
++			codeAction.command = {
++				command: ApplyFixAllCodeAction.ID,
++				arguments: [<ApplyFixAllCodeAction_args>{ tsAction: codeAction.tsAction, combinedResponse: response }],
++				title: ''
++			};
+ 		}
+ 
+ 		return codeAction;
+@@ -372,7 +379,7 @@ class TypeScriptQuickFixProvider implements vscode.CodeActionProvider<VsCodeCode
+ 		codeAction.diagnostics = [diagnostic];
+ 		codeAction.command = {
+ 			command: ApplyCodeActionCommand.ID,
+-			arguments: [<ApplyCodeActionCommand_args>{ action: tsAction, diagnostic, document, followupAction }],
++			arguments: commandsConverter[ApplyCodeActionCommand.ID].toArgs(...[<ApplyCodeActionCommand_args>{ action: tsAction, diagnostic, document, followupAction }]),
+ 			title: ''
+ 		};
+ 		return codeAction;
+@@ -409,7 +416,7 @@ class TypeScriptQuickFixProvider implements vscode.CodeActionProvider<VsCodeCode
+ 		action.diagnostics = [diagnostic];
+ 		action.command = {
+ 			command: ApplyFixAllCodeAction.ID,
+-			arguments: [<ApplyFixAllCodeAction_args>{ action }],
++			arguments: [<ApplyFixAllCodeAction_args>{ tsAction: action.tsAction, combinedResponse: action.combinedResponse }],
+ 			title: ''
+ 		};
+ 		results.addFixAllAction(tsAction.fixId, action);
+diff --git a/src/languageFeatures/refactor.ts b/src/languageFeatures/refactor.ts
+index ace340a..7ec25b1 100644
+--- a/src/languageFeatures/refactor.ts
++++ b/src/languageFeatures/refactor.ts
+@@ -20,6 +20,7 @@ import { coalesce } from '../utils/arrays';
+ import { nulToken } from '../utils/cancellation';
+ import FormattingOptionsManager from './fileConfigurationManager';
+ import { conditionalRegistration, requireSomeCapability } from './util/dependentRegistration';
++import { commandsConverter } from '../../../share';
+ 
+ function toWorkspaceEdit(client: ITypeScriptServiceClient, edits: readonly Proto.FileCodeEdits[]): vscode.WorkspaceEdit {
+ 	const workspaceEdit = new vscode.WorkspaceEdit();
+@@ -363,18 +364,12 @@ class InlinedCodeAction extends vscode.CodeAction {
+ 			// Disable renames in interactive playground https://github.com/microsoft/vscode/issues/75137
+ 			if (this.document.uri.scheme !== fileSchemes.walkThroughSnippet) {
+ 				this.command = {
+-					command: CompositeCommand.ID,
+ 					title: '',
+-					arguments: coalesce([
+-						this.command,
+-						{
+ 							command: 'editor.action.rename',
+-							arguments: [[
++							arguments: commandsConverter['editor.action.rename'].toArgs(...[[
+ 								this.document.uri,
+ 								typeConverters.Position.fromLocation(response.body.renameLocation)
+-							]]
+-						}
+-					])
++							] as const])
+ 				};
+ 			}
+ 		}
+@@ -404,7 +399,7 @@ class MoveToFileCodeAction extends vscode.CodeAction {
+ 		this.command = {
+ 			title: action.description,
+ 			command: MoveToFileRefactorCommand.ID,
+-			arguments: [<MoveToFileRefactorCommand.Args>{ action, document, range }]
++			arguments: commandsConverter[MoveToFileRefactorCommand.ID].toArgs(...[<MoveToFileRefactorCommand.Args>{ action, document, range }])
+ 		};
+ 	}
+ }
+@@ -419,7 +414,7 @@ class SelectCodeAction extends vscode.CodeAction {
+ 		this.command = {
+ 			title: info.description,
+ 			command: SelectRefactorCommand.ID,
+-			arguments: [<SelectRefactorCommand.Args>{ action: this, document, refactor: info, rangeOrSelection }]
++			arguments: commandsConverter[SelectRefactorCommand.ID].toArgs(...[<SelectRefactorCommand.Args>{ action: this, document, refactor: info, rangeOrSelection }])
+ 		};
+ 	}
+ }

--- a/packages/service/src/service/protocol.ts
+++ b/packages/service/src/service/protocol.ts
@@ -1,5 +1,4 @@
 import { CodeActionKind } from "vscode-languageserver-protocol";
-import { CodeActionCache } from "./codeAction";
 import { CompletionCache } from "./completion";
 import { tsCommands } from "./pkgJson";
 
@@ -44,7 +43,7 @@ export const semanticTokenModifiers = [
   "local",
 ];
 
-export const commands = [...tsCommands, CodeActionCache.id, CompletionCache.id];
+export const commands = [...tsCommands, CompletionCache.id];
 
 export const onTypeFormatFirstTriggerCharacter = ";";
 export const onTypeFormatMoreTriggerCharacter = ["}", "\n"];

--- a/packages/service/src/share/commandsConverter.ts
+++ b/packages/service/src/share/commandsConverter.ts
@@ -1,0 +1,106 @@
+import type * as Proto from "@vsc-ts/tsServer/protocol/protocol";
+import type * as vscode from "vscode";
+import * as lsp from "vscode-languageserver-protocol";
+import { URI } from "vscode-uri";
+import { WorkspaceShimService } from "../shims/workspace";
+import { TSLspConverter } from "../utils/converter";
+
+export function createCommandsConverter(
+  converter: TSLspConverter,
+  workspaceService: WorkspaceShimService
+) {
+  function getOpenedDoc(uri: lsp.URI) {
+    const lspDoc = workspaceService.$getDocumentByLspUri(uri);
+    if (!lspDoc) {
+      throw new Error(`Cannot find docuemnt ${uri}`);
+    }
+    return converter.convertTextDocuemntFromLsp(lspDoc);
+  }
+
+  return {
+    // NOTE: from getCommand in languageFeatures/codeLens/implementationsCodeLens.ts
+    "editor.action.showReferences": {
+      toArgs: (
+        document: vscode.Uri,
+        codeLensStart: vscode.Position,
+        locations: vscode.Location[]
+      ) => [
+        document.toString(),
+        converter.convertPositionToLsp(codeLensStart),
+        locations.map(converter.convertLocation),
+      ],
+    },
+    "editor.action.rename": {
+      toArgs: (...renamings: (readonly [vscode.Uri, vscode.Position])[]) =>
+        renamings.map(([uri, position]) => [
+          uri.toString(),
+          converter.convertPositionToLsp(position),
+        ]),
+    },
+    "typescript.goToSourceDefinition": {
+      fromArgs: (uri: lsp.URI, position: lsp.Position) => [
+        getOpenedDoc(uri),
+        converter.convertPositionFromLsp(position),
+      ],
+      toRes: (locations: vscode.Location[]) => locations.map(converter.convertLocation),
+    },
+    "typescript.findAllFileReferences": {
+      fromArgs: (uri: lsp.URI) => [URI.parse(uri)],
+      toRes: (locations: vscode.Location[]) => locations.map(converter.convertLocation),
+    },
+    "_typescript.moveToFileRefactoring": {
+      toArgs: ({
+        action,
+        document,
+        range,
+      }: {
+        action: Proto.RefactorActionInfo;
+        document: vscode.TextDocument;
+        range: vscode.Range;
+      }) => [action, document.uri.toString(), converter.convertRangeToLsp(range)],
+      fromArgs: (action: Proto.RefactorActionInfo, uri: lsp.URI, range: lsp.Range) => [
+        {
+          action,
+          document: getOpenedDoc(uri),
+          range: converter.convertRangeFromLsp(range),
+        },
+      ],
+    },
+    "_typescript.selectRefactoring": {
+      toArgs: ({
+        document,
+        refactor,
+        rangeOrSelection,
+      }: {
+        document: vscode.TextDocument;
+        refactor: Proto.ApplicableRefactorInfo;
+        rangeOrSelection: vscode.Range | vscode.Selection;
+      }) => [document.uri.toString(), refactor, converter.convertRangeToLsp(rangeOrSelection)],
+      fromArgs: (uri: lsp.URI, refactor: Proto.ApplicableRefactorInfo, range: lsp.Range) => [
+        {
+          document: getOpenedDoc(uri),
+          refactor,
+          rangeOrSelection: converter.convertRangeFromLsp(range),
+        },
+      ],
+    },
+    "_typescript.applyCodeActionCommand": {
+      toArgs: ({
+        action,
+        diagnostic,
+        document,
+      }: {
+        action: Proto.CodeFixAction;
+        diagnostic: vscode.Diagnostic;
+        document: vscode.TextDocument;
+      }) => [action, converter.convertDiagnosticToLsp(diagnostic), document.uri.toString()],
+      fromArgs: (action: Proto.CodeFixAction, diagnostic: lsp.Diagnostic, uri: lsp.URI) => [
+        {
+          action,
+          diagnostic: converter.convertDiagnosticFromLsp(diagnostic),
+          document: getOpenedDoc(uri),
+        },
+      ],
+    },
+  };
+}

--- a/packages/service/src/share/index.ts
+++ b/packages/service/src/share/index.ts
@@ -1,0 +1,14 @@
+import { WorkspaceShimService } from "../shims/workspace";
+import { TSLspConverter } from "../utils/converter";
+import { createCommandsConverter } from "./commandsConverter";
+
+export let commandsConverter: ReturnType<typeof createCommandsConverter>;
+
+export function initializeShareMod(
+  converter: TSLspConverter,
+  workspaceService: WorkspaceShimService
+) {
+  commandsConverter = createCommandsConverter(converter, workspaceService);
+
+  return { commandsConverter };
+}

--- a/packages/service/src/shims/commands.ts
+++ b/packages/service/src/shims/commands.ts
@@ -48,6 +48,13 @@ export class CommandsShimService extends Disposable {
   }
 
   async executeCommand<T, A extends any[]>(id: string, ...args: A): Promise<T | undefined> {
+    if (id.startsWith("editor.")) {
+      this.delegate.logMessage(
+        lsp.MessageType.Error,
+        `Command ${id} is an client side command and should not be sent to server for execution`
+      );
+      return;
+    }
     const command = this._commands.get(id);
     if (!command) {
       this.delegate.logMessage(lsp.MessageType.Error, `Command ${id} not found`);

--- a/packages/service/tests/utils.ts
+++ b/packages/service/tests/utils.ts
@@ -1,8 +1,9 @@
 import * as fs from "node:fs/promises";
+import * as path from "node:path";
 import * as lsp from "vscode-languageserver-protocol";
 import { TextDocument } from "vscode-languageserver-textdocument";
 import { URI } from "vscode-uri";
-import { createTSLanguageService, TSLanguageService } from "../src/service";
+import { createTSLanguageService } from "../src/service";
 
 export async function createTestService(workspacePath: string) {
   const service = createTSLanguageService({
@@ -11,11 +12,17 @@ export async function createTestService(workspacePath: string) {
         documentSymbol: { hierarchicalDocumentSymbolSupport: true },
         definition: { linkSupport: true },
       },
+      workspace: {
+        workspaceEdit: {
+          resourceOperations: [lsp.ResourceOperationKind.Create],
+        },
+      },
     },
     workspaceFolders: [{ name: "test", uri: URI.file(workspacePath).toString() }],
   });
 
   service.onLogMessage((p) => console.log(p.message));
+  service.onShowDocument(async () => true);
 
   await service.initialize({
     typescript: {
@@ -33,46 +40,56 @@ export async function createTestService(workspacePath: string) {
         useSyntaxServer: "never",
       },
     },
+    vtsls: {
+      typescript: {
+        format: {
+          newLineCharacter: "\n"
+        }
+      }
+    }
   });
 
-  return service;
-}
+  const openedDocuments = new Map<string, { uri: string, doc: TextDocument, closeDoc: () => void, changeContent: (text: string) => void }>;
 
-export async function openDoc(
-  service: TSLanguageService,
-  uri: string,
-  text?: string,
-  languageId = "typescript"
-) {
-  const resolvedText = text ?? (await readFsUriContent(uri));
-  service.openTextDocument({
-    textDocument: {
+  const openDoc = async (docPath: string, opts?: { text?: string; languageId?: string }) => {
+    const uri = URI.file(path.resolve(workspacePath, docPath)).toString();
+    const resolvedText = opts?.text ?? (await readFsUriContent(uri));
+    const maybeOpened = openedDocuments.get(docPath);
+    if (maybeOpened) {
+      maybeOpened.changeContent(resolvedText);
+      return maybeOpened;
+    }
+
+    service.openTextDocument({
+      textDocument: {
+        uri,
+        languageId: opts?.languageId || "typescript",
+        version: 0,
+        text: resolvedText,
+      },
+    });
+
+    const doc = TextDocument.create(uri, "typescript", 0, resolvedText);
+    const entry = {
       uri,
-      languageId,
-      version: 0,
-      text: resolvedText,
-    },
-  });
+      doc,
+      closeDoc: () => { service.closeTextDocument({ textDocument: { uri } }); openedDocuments.delete(docPath) },
+      changeContent: (text: string) => {
+        service.changeTextDocument({
+          textDocument: { uri, version: doc.version + 1 },
+          contentChanges: [{ text }],
+        });
+        TextDocument.update(doc, [{ text }], doc.version + 1);
+      },
+    };
 
-  service.changeTextDocument({
-    textDocument: { uri, version: 0 },
-    contentChanges: [{ text: resolvedText }],
-  });
-
-  const doc = TextDocument.create(uri, "typescript", 0, resolvedText);
-
-  return {
-    doc,
-    close: () => service.closeTextDocument({ textDocument: { uri } }),
-    change: (text: string) => {
-      service.changeTextDocument({
-        textDocument: { uri, version: doc.version + 1 },
-        contentChanges: [{ text }],
-      });
-      TextDocument.update(doc, [{ text }], doc.version + 1);
-    },
+    openedDocuments.set(docPath, entry);
+    return entry;
   };
+
+  return { service, openDoc };
 }
+
 async function readFsUriContent(uri: string) {
   try {
     const fsPath = URI.parse(uri).fsPath;

--- a/packages/service/tests/workspace/bar.ts
+++ b/packages/service/tests/workspace/bar.ts
@@ -1,0 +1,1 @@
+import "./foo";


### PR DESCRIPTION
First step to resolve the dirty hack for code action cache. This also makes it possible to allow the client to automatically trigger rename of symbol after refactor action applied by `editor.action.rename` command.

<details>
  <summary>Example for rename</summary>

   https://github.com/yioneko/vtsls/assets/65551246/eaf8daeb-18b8-41e6-9dd6-3a17b64638fd
</details>

