### PR TITLE
feat: truncate inlay hint by setting

### DIFF
--- a/packages/service/configuration.schema.json
+++ b/packages/service/configuration.schema.json
@@ -1097,6 +1097,14 @@
       ],
       "description": "Maximum number of completion entries to return. Recommend to also toggle `enableServerSideFuzzyMatch` to preserve items with higher accuracy."
     },
+    "vtsls.experimental.maxInlayHintLength": {
+      "default": null,
+      "type": [
+        "number",
+        "null"
+      ],
+      "description": "Maximum length of single inlay hint. Note that hint is simply truncated if the limit is exceeded. Do not set this if your client already handles overly long hints gracefully."
+    },
     "vtsls.enableMoveToFileCodeAction": {
       "default": false,
       "type": "boolean",

--- a/packages/service/patches/450-fix-tsc-err.patch
+++ b/packages/service/patches/450-fix-tsc-err.patch
@@ -11,16 +11,3 @@ index 8fd7ce4..b1d24bc 100644
  import VsCodeTelemetryReporter from '@vscode/extension-telemetry';
  import * as vscode from 'vscode';
  import * as tas from 'vscode-tas-client';
-diff --git a/src/typescriptServiceClient.ts b/src/typescriptServiceClient.ts
-index 25dfca2..01dbf29 100644
---- a/src/typescriptServiceClient.ts
-+++ b/src/typescriptServiceClient.ts
-@@ -1060,7 +1060,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
- 	private addWatchEvent(id: number, eventType: keyof WatchEvent, path: string) {
- 		let event = this.watchEvents.get(id);
- 		const removeEvent = (typeOfEventToRemove: keyof WatchEvent) => {
--			if (event?.[typeOfEventToRemove]?.delete(path) && event[typeOfEventToRemove].size === 0) {
-+			if (event?.[typeOfEventToRemove]?.delete(path) && event[typeOfEventToRemove]?.size === 0) {
- 				event[typeOfEventToRemove] = undefined;
- 			}
- 		};

--- a/packages/service/scripts/genConfigSchema.js
+++ b/packages/service/scripts/genConfigSchema.js
@@ -115,6 +115,12 @@ async function genSchema() {
       description:
         "Maximum number of completion entries to return. Recommend to also toggle `enableServerSideFuzzyMatch` to preserve items with higher accuracy.",
     },
+    "vtsls.experimental.maxInlayHintLength": {
+      default: null,
+      type: ["number", "null"],
+      description:
+        "Maximum length of single inlay hint. Note that hint is simply truncated if the limit is exceeded. Do not set this if your client already handles overly long hints gracefully.",
+    },
     "vtsls.enableMoveToFileCodeAction": {
       default: false,
       type: "boolean",

--- a/packages/service/src/service/inlayHint.ts
+++ b/packages/service/src/service/inlayHint.ts
@@ -1,0 +1,89 @@
+import * as vscode from "vscode";
+import * as lsp from "vscode-languageserver-protocol";
+import { ConfigurationShimService } from "../shims/configuration";
+import { LanguageFeatureRegistryHandle } from "../shims/languageFeatures";
+import { TSLspConverter } from "../utils/converter";
+import { isNil } from "../utils/types";
+
+export class TSInlayHintFeature {
+  constructor(
+    private registry: LanguageFeatureRegistryHandle<vscode.InlayHintsProvider, unknown>,
+    private configuration: ConfigurationShimService,
+    private converter: TSLspConverter
+  ) {}
+
+  async inlayHint(
+    doc: vscode.TextDocument,
+    params: Omit<lsp.InlayHintParams, "textDocument">,
+    token: lsp.CancellationToken
+  ) {
+    const maxHintLength = this.configuration
+      .getConfiguration("vtsls.experimental")
+      .get<number | null>("maxInlayHintLength");
+
+    const { provider } = this.registry.getHighestProvider(doc);
+    const result = await provider.provideInlayHints(
+      doc,
+      this.converter.convertRangeFromLsp(params.range),
+      token
+    );
+
+    if (!result) {
+      return;
+    }
+
+    let converted = result.map(this.converter.convertInlayHint);
+    if (!isNil(maxHintLength)) {
+      const ellipsis = "…";
+      converted = converted.map((hint) => {
+        const originalLabel = hint.label;
+        const { truncated, label } = truncateLabel(
+          originalLabel,
+          Math.max(maxHintLength, ellipsis.length),
+          ellipsis
+        );
+        if (truncated) {
+          hint.label = label;
+          // set original label in data if truncated
+          hint.data = { originalLabel };
+        }
+        return hint;
+      });
+    }
+
+    return converted;
+  }
+}
+
+function truncateLabel(label: lsp.InlayHint["label"], limit: number, ellipsis: string) {
+  if (typeof label == "string") {
+    if (label.length <= limit) {
+      return { truncated: false, label };
+    } else {
+      return {
+        truncated: true,
+        label: `${label.substring(0, limit - ellipsis.length)}${ellipsis}`,
+      };
+    }
+  }
+  const withInLimit =
+    label.reduce((labelLength, part) => labelLength + part.value.length, 0) <= limit;
+  if (withInLimit) {
+    return { truncated: false, label };
+  }
+  let labelRemaining = limit - ellipsis.length;
+  const labelParts: lsp.InlayHintLabelPart[] = [];
+  for (const part of label) {
+    if (part.value.length < labelRemaining) {
+      labelParts.push(part);
+      labelRemaining -= part.value.length;
+    } else {
+      labelParts.push({
+        ...part,
+        value: `${part.value.substring(0, labelRemaining)}${ellipsis}`,
+      });
+      break;
+    }
+  }
+  return { truncated: true, label: labelParts };
+}

--- a/packages/service/src/service/pkgJson.ts
+++ b/packages/service/src/service/pkgJson.ts
@@ -14,6 +14,7 @@ function getDefaultConfig() {
   const excludedDefaults = {
     "vtsls.experimental.completion.enableServerSideFuzzyMatch": false,
     "vtsls.experimental.completion.entriesLimit": null,
+    "vtsls.experimental.maxInlayHintLength": null,
     "vtsls.enableMoveToFileCodeAction": false,
     "vtsls.autoUseWorkspaceTsdk": false,
     "vtsls.tsserver.globalPlugins": [],

--- a/packages/service/src/shims/languageFeatures.ts
+++ b/packages/service/src/shims/languageFeatures.ts
@@ -56,7 +56,8 @@ interface ProviderWithScore<T, Args> {
 
 export interface LanguageFeatureRegistryHandle<T, Args> {
   getProviders(doc: vscode.TextDocument): ProviderWithScore<T, Args>[];
-  getProviderById(id: number): ProviderEntry<T, Args> | undefined;
+  getProviderById(id: number): ProviderEntry<T, Args>;
+  getHighestProvider(doc: vscode.TextDocument): ProviderWithScore<T, Args>;
 }
 
 type InferRegistryHandle<R extends LanguageFeatureRegistry<any>> =
@@ -212,6 +213,9 @@ class LanguageFeaturesRegistryStore extends Disposable {
       },
       getProviderById(id: number) {
         return store.$getProviderById(id, registry);
+      },
+      getHighestProvider(doc: vscode.TextDocument) {
+        return store.$getHighestProvider(doc, registry);
       },
     };
   }


### PR DESCRIPTION
Add a new config option `vtsls.experimental.maxInlayHintLength` to control the truncating.

Related #170