### PR TITLE
fix: handle zipfile uri with yarn pnp and neovim

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -39,6 +39,7 @@ function onServerInitialize(conn: Connection, params: InitializeParams) {
     locale: params.locale,
     workspaceFolders: folders,
     clientCapabilities,
+    hostInfo: params.initializationOptions?.hostInfo,
     tsExtLogPath: params.initializationOptions?.tsLogPath,
   });
 

--- a/packages/service/patches/410-handle-yarn-zipfile.patch
+++ b/packages/service/patches/410-handle-yarn-zipfile.patch
@@ -1,0 +1,62 @@
+diff --git a/src/configuration/fileSchemes.ts b/src/configuration/fileSchemes.ts
+index ca268e2..96c9f0b 100644
+--- a/src/configuration/fileSchemes.ts
++++ b/src/configuration/fileSchemes.ts
+@@ -23,6 +23,7 @@ export const chatCodeBlock = 'vscode-chat-code-block';
+ 
+ /** Used for code blocks in chat by copilot. */
+ export const chatBackingCodeBlock = 'vscode-copilot-chat-code-block';
++export const zipfile = 'zipfile';
+ 
+ export function getSemanticSupportedSchemes() {
+ 	if (isWeb() && vscode.workspace.workspaceFolders) {
+@@ -36,6 +37,7 @@ export function getSemanticSupportedSchemes() {
+ 		vscodeNotebookCell,
+ 		chatCodeBlock,
+ 		chatBackingCodeBlock,
++		zipfile
+ 	];
+ }
+ 
+diff --git a/src/typescriptServiceClient.ts b/src/typescriptServiceClient.ts
+index 25dfca2..6330dd8 100644
+--- a/src/typescriptServiceClient.ts
++++ b/src/typescriptServiceClient.ts
+@@ -572,7 +572,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
+ 			: undefined;
+ 
+ 		const configureOptions: Proto.ConfigureRequestArguments = {
+-			hostInfo: 'vscode',
++			hostInfo: (this.context as any).hostInfo || 'vscode',
+ 			preferences: {
+ 				providePrefixAndSuffixTextForRename: true,
+ 				allowRenameOfImportPath: true,
+@@ -748,6 +748,10 @@ export default class TypeScriptServiceClient extends Disposable implements IType
+ 			return resource.fsPath;
+ 		}
+ 
++		if (resource.scheme === fileSchemes.zipfile) {
++			return resource.scheme + "://" + (resource.path.startsWith('/') ? resource.path : '/' + resource.path);
++		}
++
+ 		return (this.isProjectWideIntellisenseOnWebEnabled() ? '' : inMemoryResourcePrefix)
+ 			+ '/' + resource.scheme
+ 			+ '/' + (resource.authority || emptyAuthority)
+@@ -796,6 +800,17 @@ export default class TypeScriptServiceClient extends Disposable implements IType
+ 				return this.bufferSyncSupport.toVsCodeResource(resource);
+ 			}
+ 		}
++		if (filepath.startsWith(fileSchemes.zipfile)) {
++			const uri = vscode.Uri.parse(filepath, false)
++			return new Proxy(uri, {
++				get(target, p) {
++					if (p === 'toString') {
++						return () => filepath;
++					}
++					return target[p as keyof vscode.Uri];
++				}
++			})
++		}
+ 
+ 		if (filepath.startsWith(inMemoryResourcePrefix)) {
+ 			const parts = filepath.match(/^\^\/([^\/]+)\/([^\/]*)\/(.+)$/);

--- a/packages/service/src/service/types.ts
+++ b/packages/service/src/service/types.ts
@@ -4,6 +4,7 @@ export interface TSLanguageServiceOptions {
   locale?: string;
   workspaceFolders?: lsp.WorkspaceFolder[];
   clientCapabilities: lsp.ClientCapabilities;
+  hostInfo?: string;
   tsExtLogPath?: string;
 }
 

--- a/packages/service/src/shims/context.ts
+++ b/packages/service/src/shims/context.ts
@@ -2,9 +2,10 @@ import * as vscode from "vscode";
 import { URI } from "vscode-uri";
 import { Memento } from "./memento";
 
-export function createContextShim(logPath: string) {
+export function createContextShim(logPath: string, hostInfo?: string) {
   return {
     logPath,
+    hostInfo,
     subscriptions: [],
     workspaceState: new Memento(),
     globalState: new Memento(),

--- a/packages/service/src/shims/index.ts
+++ b/packages/service/src/shims/index.ts
@@ -53,7 +53,7 @@ export function initializeShimServices(
   const diagnosticsSerivce = new DiagnosticsShimService();
   const languageFeaturesService = new LanguageFeaturesShimService(delegate, diagnosticsSerivce);
   const windowService = new WindowShimService(delegate);
-  const context = createContextShim(initOptions.tsExtLogPath ?? os.tmpdir());
+  const context = createContextShim(initOptions.tsExtLogPath ?? os.tmpdir(), initOptions.hostInfo);
 
   const dispose = () => {
     configurationService.dispose();


### PR DESCRIPTION
Resolve #177.

Extra steps to make it work in neovim:

Set `init_options.hostInfo = "neovim"` to make the yarn sdk aware of the client type and send `zipfile:///` uris.

Make sure the neovim builtin zip plugin is enabled. Edit a random zip file to test if it is working.

~~Add the following snippet to config to fix zip plugin not handling `zipfile:/` uri:~~
```lua
vim.api.nvim_create_autocmd("BufReadCmd", {
  pattern = "zipfile:/[^/]*",
  callback = function(args)
    -- the uri is like zipfile:/a/b/c
    local uri = args.match --[[@as string]]
    -- transform it to be zipfile:///a/b/c
    vim.fn["zip#Read"](uri:gsub("^zipfile:", "zipfile://"), 1)
  end,
})
```