### PR TITLE
fix(hover): return null instead of empty contents

### DIFF
--- a/packages/service/src/utils/converter.ts
+++ b/packages/service/src/utils/converter.ts
@@ -352,7 +352,7 @@ export class TSLspConverter extends LspInvariantConverter {
     }
   }
 
-  convertHover = (hover: vscode.Hover): lsp.Hover => {
+  convertHover = (hover: vscode.Hover): lsp.Hover | null => {
     const mergedString = new types.MarkdownString();
     for (const content of hover.contents) {
       if (lsp.MarkedString.is(content)) {
@@ -365,10 +365,10 @@ export class TSLspConverter extends LspInvariantConverter {
         mergedString.appendMarkdown(content.value);
       }
     }
-    return {
+    return mergedString.value ? {
       contents: mergedString.value,
       range: hover.range ? this.convertRangeToLsp(hover.range) : undefined,
-    };
+    } : null;
   };
 
   convertSymbol = (


### PR DESCRIPTION
We recently had an issue filed in Neovim about `vtsls` returning empty hover contents: https://github.com/neovim/neovim/pull/33692.

Since the LSP allows a hover request to return null, it is better aligned to the spec to return nothing when there are no contents.