### PR TITLE
fix: fixed a typo

### DIFF
--- a/packages/server/build.js
+++ b/packages/server/build.js
@@ -20,7 +20,7 @@ async function build({ watch }) {
     external: Object.keys(dependencies).flatMap((d) => [d, `${d}/*`]),
     target: "node16",
     platform: "node",
-    define: { VTSLS_VRESION: `"${version}"` },
+    define: { VTSLS_VERSION: `"${version}"` },
   };
   if (!watch) {
     return esbuild.build(opts);

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -74,7 +74,7 @@ function onServerInitialize(conn: Connection, params: InitializeParams) {
 
   return {
     capabilities,
-    serverInfo: { name: "vtsls", version: VTSLS_VRESION },
+    serverInfo: { name: "vtsls", version: VTSLS_VERSION },
   };
 }
 

--- a/packages/server/src/typings.d.ts
+++ b/packages/server/src/typings.d.ts
@@ -1,3 +1,3 @@
 /* eslint-disable no-var */
 
-declare var VTSLS_VRESION: string;
+declare var VTSLS_VERSION: string;


### PR DESCRIPTION
previously the constant for having the vtsls version at runtime was called `VTSLS_VRESION`. This was probably a typo, renamed to `VTSLS_VERSION`.