### PR TITLE
Make CLI more friendly (add: --help, --version, --print-config-schema)

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -180,4 +180,52 @@ function bindServiceHandlers(
   );
 }
 
-createLanguageServer();
+function printHelp() {
+  console.log(`vtsls v${VTSLS_VERSION}
+
+Usage: vtsls [options]
+
+Language Server Options:
+  --stdio                 Use stdio for communication (default)
+  --node-ipc              Use node-ipc for communication
+  --socket=<number>       Use socket for communication
+
+Other Options:
+  --help, -h              Show this help message
+  --version, -V           Print version information
+  --print-config-schema   Print the configuration schema as JSON
+`);
+}
+
+function printVersion() {
+  console.log(VTSLS_VERSION);
+}
+
+function printConfigSchema() {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const schema = require("@vtsls/language-service/configuration-schema");
+    console.log(JSON.stringify(schema, null, 2));
+  } catch (error) {
+    console.error(`Error: Could not load configuration schema: ${error}`);
+    console.log("{}");
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes("--help") || args.includes("-h")) {
+    printHelp();
+    process.exit(0);
+  } else if (args.includes("--version") || args.includes("-V")) {
+    printVersion();
+    process.exit(0);
+  } else if (args.includes("--print-config-schema")) {
+    printConfigSchema();
+    process.exit(0);
+  } else {
+    createLanguageServer();
+  }
+}
+
+main();

--- a/packages/service/package.json
+++ b/packages/service/package.json
@@ -10,6 +10,7 @@
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
   "files": [
+    "./configuration.schema.json",
     "./dist/index.js",
     "./dist/index.mjs",
     "./dist/**/*.d.ts"
@@ -19,7 +20,8 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./configuration-schema": "./configuration.schema.json"
   },
   "dependencies": {
     "@vscode/l10n": "^0.0.18",


### PR DESCRIPTION
- Add `--version`
  ```
  0.2.9
  ```
- Add `--help`:
  ```
  vtsls v0.2.9
  
  Usage: vtsls [options]
  
  Language Server Options:
    --stdio                 Use stdio for communication (default)
    --node-ipc              Use node-ipc for communication
    --socket=<number>       Use socket for communication
  
  Other Options:
    --help, -h              Show this help message
    --version, -V           Print version information
    --print-config-schema   Print the configuration schema as JSON
  ```

- Add `--print-config-schema` (prints [configuration.schema.json](https://github.com/yioneko/vtsls/blob/main/packages/service/configuration.schema.json) to stdout).
  ```
  {
    "$schema": "http://json-schema.org/draft-07/schema#",
    "description": "Configuration for Typescript language service",
    "properties": {
      "typescript.tsdk": {
        "type": "string",
        "markdownDescription": [...]
  ```

  The lsp being able to output the schema for lsp.settings matches prior art for other LSPs:
  - `rust-analyzer --print-config-schema`
  - `taplo config schema`
  - `haskell-language-server vscode-extension-schema`

  This makes it possible for tools (e.g. Zed) to validate user settings against the schema provided by vtsls. 

This PR does not validate any existing options (`--stdio`, etc) used by the underlying LSP, nor should it change any existing behavior. E.g. Default behavior is the same when no options are passed:

```
% node packages/server/bin/vtsls.js
/Users/peter/source/vtsls/node_modules/.pnpm/vscode-languageserver@9.0.1/node_modules/vscode-languageserver/lib/node/main.js:192
        throw new Error('Connection input stream is not set. ' + commandLineMessage);
        ^

Error: Connection input stream is not set. Use arguments of createConnection or set command line parameters: '--node-ipc', '--stdio' or '--socket={number}'
    at _createConnection (/Users/peter/source/vtsls/node_modules/.pnpm/vscode-languageserver@9.0.1/node_modules/vscode-languageserver/lib/node/main.js:192:15)
    at createConnection (/Users/peter/source/vtsls/node_modules/.pnpm/vscode-languageserver@9.0.1/node_modules/vscode-languageserver/lib/node/main.js:137:12)
    at createLanguageServer (/Users/peter/source/vtsls/packages/server/dist/main.js:109:50)
    at main (/Users/peter/source/vtsls/packages/server/dist/main.js:279:5)
    at Object.<anonymous> (/Users/peter/source/vtsls/packages/server/dist/main.js:282:1)
    at Module._compile (node:internal/modules/cjs/loader:1760:14)
    at Object..js (node:internal/modules/cjs/loader:1893:10)
    at Module.load (node:internal/modules/cjs/loader:1480:32)
    at Module._load (node:internal/modules/cjs/loader:1299:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)

Node.js v24.10.0
```