### PR TITLE
feat(hover): expandable api

### DIFF
--- a/packages/service/src/service/types.ts
+++ b/packages/service/src/service/types.ts
@@ -1,4 +1,5 @@
 import * as lsp from "vscode-languageserver-protocol";
+import type * as vscode from "vscode";
 
 export interface TSLanguageServiceOptions {
   locale?: string;
@@ -41,3 +42,14 @@ export type TSLanguageServiceEvents = {
     handler: EventHandlersMapping[K]
   ) => lsp.Disposable;
 };
+
+export interface VerboseHover extends lsp.Hover {
+  canDecreaseVerbosity?: boolean;
+  canIncreaseVerbosity?: boolean;
+}
+
+export interface VerboseHoverParams extends lsp.HoverParams {
+  context?: {
+    verbosityRequest: vscode.HoverContext;
+  }
+}

--- a/packages/service/src/utils/converter.ts
+++ b/packages/service/src/utils/converter.ts
@@ -5,6 +5,7 @@ import * as types from "../shims/types";
 import { onCaseInsensitiveFileSystem } from "../utils/fs";
 import { ResourceMap } from "../utils/resourceMap";
 import { deepClone } from "./objects";
+import type { VerboseHover } from "../service/types";
 
 function isStringOrFalsy(val: unknown): val is string | undefined | null {
   return typeof val === "string" || val === undefined || val === null;
@@ -352,7 +353,7 @@ export class TSLspConverter extends LspInvariantConverter {
     }
   }
 
-  convertHover = (hover: vscode.Hover): lsp.Hover | null => {
+  convertHover = (hover: vscode.VerboseHover): VerboseHover | null => {
     const mergedString = new types.MarkdownString();
     for (const content of hover.contents) {
       if (lsp.MarkedString.is(content)) {
@@ -365,9 +366,12 @@ export class TSLspConverter extends LspInvariantConverter {
         mergedString.appendMarkdown(content.value);
       }
     }
+    const { canDecreaseVerbosity, canIncreaseVerbosity } = hover;
     return mergedString.value ? {
       contents: mergedString.value,
       range: hover.range ? this.convertRangeToLsp(hover.range) : undefined,
+      canDecreaseVerbosity,
+      canIncreaseVerbosity
     } : null;
   };
 


### PR DESCRIPTION
## Description

This PR implements the server-side logic for **Expandable Hover (Verbose Hover)**.

The language server will now forward `canIncreaseVerbosity` and `canDecreaseVerbosity` flags from `tsserver` to the client. Additionally, it handles the incoming `verbosityDelta` from the client and passes it back to `tsserver` to retrieve hover content at different expansion levels.

The interface design follows the existing VS Code hover API structure to ensure compatibility and familiarity.

## Notes

Please let me know if there are any concerns regarding the API design or if any adjustments are needed to better fit the project structure.

## Related Issue

Closes #260

<img width="1925" height="715" alt="image" src="https://github.com/user-attachments/assets/4ea8e2ba-10d4-46bc-9a67-27c0f812c81b" />
<img width="1931" height="786" alt="image" src="https://github.com/user-attachments/assets/b6f9f7d5-e5bf-4e84-8f4a-8375bd89f739" />
<img width="1875" height="736" alt="image" src="https://github.com/user-attachments/assets/01f77933-9bae-41fb-a2a8-f45c50190b74" />
