### PR TITLE
fix: provide initial value for reduce in completion fuzzy scorer

### DIFF
--- a/packages/service/src/service/completion.ts
+++ b/packages/service/src/service/completion.ts
@@ -177,7 +177,7 @@ export class TSCompletionFeature extends Disposable {
     const shouldFuzzy = enableServerSideFuzzyMatch && wordRange;
     const fuzzyScorer = shouldFuzzy
       ? this.getCompletionItemFuzzyScorer(
-        results.map((r) => r.items.length).reduce((a, b) => a + b),
+        results.map((r) => r.items.length).reduce((a, b) => a + b, 0),
         pos,
         wordRange,
         leadingLineContent


### PR DESCRIPTION
## Problem

When all completion providers return either `null`/`undefined` or empty arrays, `results` ends up empty and the subsequent `[].reduce((a, b) => a + b)` in `packages/service/src/service/completion.ts` throws:

```
TypeError: Reduce of empty array with no initial value
```

The error surfaces to LSP clients as a failed `textDocument/completion` request, which (depending on client behavior) can block the completion menu entirely.

## Reproduction

Reliably reproducible in any Next.js 16 project. Next.js's TypeScript plugin (`node_modules/next/dist/server/typescript/index.js`) wraps `info.languageService.getCompletionEntryDetails`. When TypeScript core's `getCompletionEntryCodeActionsAndSourceDisplay` throws a `Debug Failure. False expression.` (an assertion inside TS itself), the plugin's wrapper propagates it. All upstream sources return empty, `results` is empty, and this `.reduce()` throws.

The stack the client sees:
\`\`\`
Request textDocument/completion failed with message:
  Reduce of empty array with no initial value
\`\`\`

## Fix

Pass \`0\` as the initial value to \`.reduce()\`. Behavior for non-empty \`results\` is unchanged; the empty case now returns \`0\` (no items) instead of throwing.

\`\`\`diff
- results.map((r) => r.items.length).reduce((a, b) => a + b),
+ results.map((r) => r.items.length).reduce((a, b) => a + b, 0),
\`\`\`

## Editor-side impact

I hit this in Zed, where one provider's failed completion held the completion menu up for ~15s waiting on the broken response. With the fix, vtsls returns empty results gracefully and the menu shows results from other providers (e.g. Tailwind LSP) immediately.

## Notes

- Single-character change; no new test added (would only assert native `Array.prototype.reduce` behavior).
- Pre-commit hook (lint-staged + eslint) passes.