### PR TITLE
fix: ignore unsupported text document URIs

### DIFF
--- a/packages/service/src/shims/workspace.ts
+++ b/packages/service/src/shims/workspace.ts
@@ -18,6 +18,24 @@ export class DocumentNotOpenedError extends Error {
   }
 }
 
+const supportedTextDocumentSchemes = new Set([
+  "file",
+  "untitled",
+  "walkthroughsnippet",
+  "vscode-notebook-cell",
+  "vscode-chat-code-block",
+  "office-script",
+  "zipfile",
+]);
+
+function getUriScheme(uri: string) {
+  return /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(uri)?.[1];
+}
+
+function isSupportedTextDocumentUri(uri: URI) {
+  return supportedTextDocumentSchemes.has(uri.scheme.toLowerCase());
+}
+
 export class WorkspaceShimService extends Disposable {
   private _onDidOpenTextDocument = this._register(new lsp.Emitter<vscode.TextDocument>());
   readonly onDidOpenTextDocument = this._onDidOpenTextDocument.event;
@@ -80,6 +98,27 @@ export class WorkspaceShimService extends Disposable {
     return this._fs;
   }
 
+  private $parseTextDocumentUri(uri: lsp.URI) {
+    try {
+      const parsed = URI.parse(uri);
+      if (!isSupportedTextDocumentUri(parsed)) {
+        this.delegate.logTrace(
+          `Ignored text document with unsupported URI scheme "${parsed.scheme}": ${uri}`
+        );
+        return;
+      }
+      return parsed;
+    } catch (error) {
+      const scheme = getUriScheme(uri);
+      this.delegate.logTrace(
+        `Ignored text document with invalid URI${scheme ? ` scheme "${scheme}"` : ""}: ${String(
+          error
+        )}`
+      );
+      return;
+    }
+  }
+
   get textDocuments(): vscode.TextDocument[] {
     return Array.from(this._documents.values());
   }
@@ -93,7 +132,8 @@ export class WorkspaceShimService extends Disposable {
   }
 
   $getOpenedDoc(uri: lsp.URI) {
-    return this._documents.get(URI.parse(uri));
+    const vsUri = this.$parseTextDocumentUri(uri);
+    return vsUri ? this._documents.get(vsUri) : undefined;
   }
 
   $getOpenedDocThrow(uri: lsp.URI) {
@@ -108,8 +148,12 @@ export class WorkspaceShimService extends Disposable {
     const {
       textDocument: { uri, languageId, version, text },
     } = params;
+    const vsUri = this.$parseTextDocumentUri(uri);
+    if (!vsUri) {
+      return;
+    }
     const doc = TextDocument.create(uri, languageId, version, text);
-    this._documents.set(URI.parse(uri), doc);
+    this._documents.set(vsUri, doc);
     this._onDidOpenTextDocument.fire(doc);
   }
 
@@ -118,7 +162,11 @@ export class WorkspaceShimService extends Disposable {
       textDocument: { uri, version },
       contentChanges: changes,
     } = params;
-    const doc = this._documents.get(URI.parse(uri));
+    const vsUri = this.$parseTextDocumentUri(uri);
+    if (!vsUri) {
+      return;
+    }
+    const doc = this._documents.get(vsUri);
     if (!doc) {
       this.delegate.logMessage(lsp.MessageType.Error, `File ${uri} not found`);
       return;
@@ -148,7 +196,10 @@ export class WorkspaceShimService extends Disposable {
     const {
       textDocument: { uri },
     } = params;
-    const vsUri = URI.parse(uri);
+    const vsUri = this.$parseTextDocumentUri(uri);
+    if (!vsUri) {
+      return;
+    }
     const doc = this._documents.get(vsUri);
     if (doc) {
       this._onDidCloseTextDocument.fire(doc);

--- a/packages/service/tests/features.test.ts
+++ b/packages/service/tests/features.test.ts
@@ -199,6 +199,43 @@ function abc(a) {}`,
     });
   });
 
+  it("ignores unsupported text document uris without breaking existing documents", async () => {
+    const unsupportedUris = ["oil:////Users/me/project/src/", "oil:///Users/me/project/src/"];
+    for (const uri of unsupportedUris) {
+      expect(() =>
+        service.openTextDocument({
+          textDocument: {
+            uri,
+            languageId: "typescript",
+            version: 0,
+            text: "const fromOil = true;",
+          },
+        })
+      ).not.toThrow();
+      expect(() =>
+        service.changeTextDocument({
+          textDocument: { uri, version: 1 },
+          contentChanges: [{ text: "const changedFromOil = true;" }],
+        })
+      ).not.toThrow();
+      expect(() => service.closeTextDocument({ textDocument: { uri } })).not.toThrow();
+    }
+
+    const { uri } = await openDoc("index.ts", {
+      text: "function stillWorks() {} stillWorks()",
+    });
+    const response = await service.definition({
+      textDocument: { uri },
+      position: { line: 0, character: 25 },
+    });
+    assert(response);
+    const def = Array.isArray(response) ? response[0] : response;
+    expect(def).toMatchObject({
+      targetUri: uri,
+      targetSelectionRange: { end: { character: 19, line: 0 }, start: { character: 9, line: 0 } },
+    });
+  });
+
   it("provide quickfix", async () => {
     const { uri, changeContent } = await openDoc("index.ts");
     const diagnostics = await new Promise<lsp.Diagnostic[]>((resolve) => {


### PR DESCRIPTION
## Summary
- Ignore invalid or unsupported `textDocument` URI schemes before creating/tracking shim text documents.
- Prevent `vscode-uri` `UriError` from escaping when clients accidentally send `oil:////...`/`oil:///...` buffers.
- Add a regression test that sends Oil-style unsupported URIs, then verifies normal TypeScript definition requests still work.

## Test Plan
- `pnpm --filter @vtsls/language-service exec vitest run tests/features.test.ts -t "ignores unsupported text document uris without breaking existing documents"`
- `pnpm --filter @vtsls/language-service test`
- `pnpm test`
- `pnpm --filter @vtsls/language-service type-check`
- `pnpm type-check`
- `pnpm eslint`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
- Independent pre-commit review: passed; no security concerns or logic errors.
